### PR TITLE
Release Version 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0 - November 20, 2023
+
+- Adds support for CocoaPods.
+
 ## 0.6.0 - November 14, 2023
 
 - **Breaking:** The Mobile Checkout SDK has been rebranded to the Shopify Checkout Kit for Swift. To match this new name, the package has been renamed to `ShopifyCheckoutKit`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The SDK is an open-source [Swift Package library](https://www.swift.org/package-
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/Shopify/checkout-kit-swift", from: "0.6.0")
+  .package(url: "https://github.com/Shopify/checkout-kit-swift", from: "0.7.0")
 ]
 ```
 

--- a/ShopifyCheckoutKit.podspec
+++ b/ShopifyCheckoutKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "0.6.0"
+  s.version = "0.7.0"
 
   s.name    = "ShopifyCheckoutKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutKit/ShopifyCheckoutKit.swift
+++ b/Sources/ShopifyCheckoutKit/ShopifyCheckoutKit.swift
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 import UIKit
 
 /// The version of the `ShopifyCheckoutKit` library.
-public let version = "0.6.0"
+public let version = "0.7.0"
 
 /// The configuration options for the `ShopifyCheckoutKit` library.
 public var configuration = Configuration() {


### PR DESCRIPTION
### What are you trying to accomplish?

Bumps the version to 0.7.0.

**Note:** This is required because CocoaPods spec linting checks against the live tag, and `0.6` was missing necessary code changes.

### Before you deploy

- [ ] I have added tests to support my implementation
- [ ] I have read and agree with the contributing documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CONTRIBUTING.md)
- [ ] I have read and agree with the code of conduct documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/shopify/mobile-checkout-sdk-ios) (if applicable).
