### PR TITLE
enable/disable caching only after preloading function is called. Remo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,25 +160,17 @@ ShopifyCheckoutKit.configuration.backgroundColor = .systemBackground
 
 Initializing a checkout session requires communicating with Shopify servers and, depending on the network weather and the quality of the buyer's connection, can result in undesirable waiting time for the buyer. To help optimize and deliver the best experience, the SDK provides a preloading hint that allows app developers to signal and initialize the checkout session in the background and ahead of time.
 
-Preloading is an advanced feature that can be disabled via a runtime flag:
-
-```swift
-ShopifyCheckoutKit.configure {
-  $0.preloading.enabled = false // defaults to true
-}
-```
-
-Once enabled, preloading a checkout is as simple as:
-
+Preloading is an advanced feature that will only be activated after calling:
 ```swift
 ShopifyCheckoutKit.preload(checkout: checkoutURL)
 ```
 
 **Important considerations:**
 
-1. Initiating preload results in background network requests and additional CPU/memory utilization for the client, and should be used when there is a high likelihood that the buyer will soon request to checkout—e.g. when the buyer navigates to the cart overview or a similar app-specific experience.
-2. A preloaded checkout session reflects the cart contents at the time when `preload` is called. If the cart is updated after `preload` is called, the application needs to call `preload` again to reflect the updated checkout session.
-3. Calling `preload(checkout:)` is a hint, not a guarantee: the library may debounce or ignore calls to this API depending on various conditions; the preload may not complete before `present(checkout:)` is called, in which case the buyer may still see a spinner while the checkout session is finalized.
+1. Once you call preload, the checkout view is *cached*. _you must remember to call preload again on every cart update._ Otherwise you risk the user checking out with a stale cart
+2. Initiating preload results in background network requests and additional CPU/memory utilization for the client, and should be used when there is a high likelihood that the buyer will soon request to checkout—e.g. when the buyer navigates to the cart overview or a similar app-specific experience.
+3. A preloaded checkout session reflects the cart contents at the time when `preload` is called. If the cart is updated after `preload` is called, the application needs to call `preload` again to reflect the updated checkout session.
+4. Calling `preload(checkout:)` is a hint, not a guarantee: the library may debounce or ignore calls to this API depending on various conditions; the preload may not complete before `present(checkout:)` is called, in which case the buyer may still see a spinner while the checkout session is finalized.
 
 ### Monitoring the lifecycle of a checkout session
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Preloading is an advanced feature that will only be activated after calling:
 ShopifyCheckoutKit.preload(checkout: checkoutURL)
 ```
 
+Once preload is called, the checkout view is cached. You are expected to re-call preload every time you need to refresh the checkout view. If for whatever reason you need to invalidate the cache without calling checkout again, you can call this function:
+```swift
+ShopifyCheckoutKit.configuration.preloading.invalidateAllCaches()
+```
+
 **Important considerations:**
 
 1. Once you call preload, the checkout view is *cached*. _you must remember to call preload again on every cart update._ Otherwise you risk the user checking out with a stale cart

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ ShopifyCheckoutKit.preload(checkout: checkoutURL)
 
 Once preload is called, the checkout view is cached. You are expected to re-call preload every time you need to refresh the checkout view. If for whatever reason you need to invalidate the cache without preloading/loading the checkout view again (e.g we use this during testing of our sample app), you can call this function:
 ```swift
-ShopifyCheckoutKit.configuration.preloading.invalidateAllCaches()
+ShopifyCheckoutKit.configuration.preloading.clearCache()
 ```
 
 **Important considerations:**

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ ShopifyCheckoutKit.configuration.preloading.invalidateAllCaches()
 
 **Important considerations:**
 
-1. Once you call preload, the checkout view is *cached*. _you must remember to call preload again on every cart update._ Otherwise you risk the user checking out with a stale cart
+1. Once you call `preload()`, the checkout view will be **cached**. **You must call `preload()` again on every cart update**. Otherwise you risk the user checking out with a stale cart.
 2. Initiating preload results in background network requests and additional CPU/memory utilization for the client, and should be used when there is a high likelihood that the buyer will soon request to checkout—e.g. when the buyer navigates to the cart overview or a similar app-specific experience.
 3. A preloaded checkout session reflects the cart contents at the time when `preload` is called. If the cart is updated after `preload` is called, the application needs to call `preload` again to reflect the updated checkout session.
 4. Calling `preload(checkout:)` is a hint, not a guarantee: the library may debounce or ignore calls to this API depending on various conditions; the preload may not complete before `present(checkout:)` is called, in which case the buyer may still see a spinner while the checkout session is finalized.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Preloading is an advanced feature that will only be activated after calling:
 ShopifyCheckoutKit.preload(checkout: checkoutURL)
 ```
 
-Once preload is called, the checkout view is cached. You are expected to re-call preload every time you need to refresh the checkout view. If for whatever reason you need to invalidate the cache without calling checkout again, you can call this function:
+Once preload is called, the checkout view is cached. You are expected to re-call preload every time you need to refresh the checkout view. If for whatever reason you need to invalidate the cache without preloading/loading the checkout view again (e.g we use this during testing of our sample app), you can call this function:
 ```swift
 ShopifyCheckoutKit.configuration.preloading.invalidateAllCaches()
 ```

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/AppDelegate.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/AppDelegate.swift
@@ -31,9 +31,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		ShopifyCheckoutKit.configure {
 			/// Checkout color scheme setting
 			$0.colorScheme = .automatic
-
-			/// Enable preloading
-			$0.preloading.enabled = true
 			$0.logger = FileLogger()
 		}
 

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
@@ -28,11 +28,10 @@ class SettingsViewController: UITableViewController {
 
 	// MARK: Properties
 	enum Section: Int, CaseIterable {
-		case preloading = 0
-		case vaultedState = 1
-		case colorScheme = 2
-		case version = 3
-		case logs = 4
+		case vaultedState = 0
+		case colorScheme = 1
+		case version = 2
+		case logs = 3
 		case undefined = -1
 
 		static func from(_ rawValue: Int) -> Section {
@@ -115,8 +114,6 @@ class SettingsViewController: UITableViewController {
 
 	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
 		switch Section.from(section) {
-		case Section.preloading:
-			return 1
 		case Section.vaultedState:
 			return 1
 		case Section.colorScheme:
@@ -136,9 +133,6 @@ class SettingsViewController: UITableViewController {
 		var content = cell.defaultContentConfiguration()
 
 		switch Section.from(indexPath.section) {
-		case Section.preloading:
-			content.text = "Preload checkout"
-			cell.accessoryView = preloadingSwitch
 		case Section.vaultedState:
 			content.text = "Prefill buyer information"
 			cell.accessoryView = vaultedStateSwitch
@@ -169,9 +163,6 @@ class SettingsViewController: UITableViewController {
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		switch Section.from(indexPath.section) {
-		case Section.preloading:
-			preloadingSwitch.isOn.toggle()
-			preloadingSwitchDidChange()
 		case Section.vaultedState:
 			vaultedStateSwitch.isOn.toggle()
 			vaultedStateSwitchDidChange()
@@ -188,10 +179,6 @@ class SettingsViewController: UITableViewController {
 	}
 
 	// MARK: Private
-
-	@objc private func preloadingSwitchDidChange() {
-		ShopifyCheckoutKit.configuration.preloading.enabled = preloadingSwitch.isOn
-	}
 
 	@objc private func vaultedStateSwitchDidChange() {
 		appConfiguration.useVaultedState = vaultedStateSwitch.isOn

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
@@ -42,13 +42,6 @@ class SettingsViewController: UITableViewController {
 
 	private var logs: [String?] = []
 
-	private lazy var preloadingSwitch: UISwitch = {
-		let view = UISwitch()
-		view.isOn = ShopifyCheckoutKit.configuration.preloading.enabled
-		view.addTarget(self, action: #selector(preloadingSwitchDidChange), for: .valueChanged)
-		return view
-	}()
-
 	private lazy var vaultedStateSwitch: UISwitch = {
 		let view = UISwitch()
 		view.isOn = appConfiguration.useVaultedState
@@ -163,7 +156,7 @@ class SettingsViewController: UITableViewController {
 	}
 
 	@objc private func clearPreloadingCache() {
-		ShopifyCheckoutKit.configuration.preloading.invalidateAllCaches()
+		ShopifyCheckoutKit.configuration.preloading.clearCache()
 	}
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Sources/ShopifyCheckoutKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutWebViewController.swift
@@ -117,7 +117,6 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
 	}
 
 	private func didCancel() {
-		CheckoutWebView.invalidate()
 		delegate?.checkoutDidCancel()
 	}
 }

--- a/Sources/ShopifyCheckoutKit/Configuration.swift
+++ b/Sources/ShopifyCheckoutKit/Configuration.swift
@@ -71,7 +71,7 @@ extension Configuration {
 	public struct Preloading {
 		internal var enabled: Bool = false
 
-		public func invalidateAllCaches() {
+		public func clearCache() {
 			CheckoutWebView.invalidate()
 		}
 	}

--- a/Sources/ShopifyCheckoutKit/Configuration.swift
+++ b/Sources/ShopifyCheckoutKit/Configuration.swift
@@ -37,13 +37,12 @@ public struct Configuration {
 
 	public var confetti = Configuration.Confetti()
 
-
 	public var spinnerColor: UIColor = UIColor(red: 0.09, green: 0.45, blue: 0.69, alpha: 1.00)
 
 	public var backgroundColor: UIColor = .systemBackground
 
 	public var logger: Logger = NoOpLogger()
-	
+
 	internal var preloading = Configuration.Preloading()
 }
 

--- a/Sources/ShopifyCheckoutKit/Configuration.swift
+++ b/Sources/ShopifyCheckoutKit/Configuration.swift
@@ -37,14 +37,14 @@ public struct Configuration {
 
 	public var confetti = Configuration.Confetti()
 
-	public var preloading = Configuration.Preloading()
 
 	public var spinnerColor: UIColor = UIColor(red: 0.09, green: 0.45, blue: 0.69, alpha: 1.00)
 
 	public var backgroundColor: UIColor = .systemBackground
 
 	public var logger: Logger = NoOpLogger()
-
+	
+	internal var preloading = Configuration.Preloading()
 }
 
 extension Configuration {
@@ -69,7 +69,7 @@ extension Configuration {
 }
 
 extension Configuration {
-	public struct Preloading {
-		public var enabled: Bool = true
+	internal struct Preloading {
+		internal var enabled: Bool = false
 	}
 }

--- a/Sources/ShopifyCheckoutKit/Configuration.swift
+++ b/Sources/ShopifyCheckoutKit/Configuration.swift
@@ -43,7 +43,7 @@ public struct Configuration {
 
 	public var logger: Logger = NoOpLogger()
 
-	internal var preloading = Configuration.Preloading()
+	public var preloading = Configuration.Preloading()
 }
 
 extension Configuration {
@@ -68,7 +68,11 @@ extension Configuration {
 }
 
 extension Configuration {
-	internal struct Preloading {
+	public struct Preloading {
 		internal var enabled: Bool = false
+
+		public func invalidateAllCaches() {
+			CheckoutWebView.invalidate()
+		}
 	}
 }

--- a/Sources/ShopifyCheckoutKit/ShopifyCheckoutKit.swift
+++ b/Sources/ShopifyCheckoutKit/ShopifyCheckoutKit.swift
@@ -40,7 +40,7 @@ public func configure(_ block: (inout Configuration) -> Void) {
 
 /// Preloads the checkout for faster presentation.
 public func preload(checkout url: URL) {
-	guard configuration.preloading.enabled else { return }
+	configuration.preloading.enabled = true
 	CheckoutWebView.for(checkout: url).load(checkout: url)
 }
 

--- a/Tests/ShopifyCheckoutKitTests/CheckoutViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutKitTests/CheckoutViewControllerTests.swift
@@ -67,29 +67,6 @@ class CheckoutViewDelegateTests: XCTestCase {
 		XCTAssertNotEqual(two, three)
 	}
 
-	func testCloseInvalidatesViewCache() {
-		let one = CheckoutWebView.for(checkout: checkoutURL)
-		let two = CheckoutWebView.for(checkout: checkoutURL)
-		XCTAssertEqual(one, two)
-
-		viewController.close()
-
-		let three = CheckoutWebView.for(checkout: checkoutURL)
-		XCTAssertNotEqual(two, three)
-	}
-
-	func testPresentationControllerDidDismissInvalidatesViewCache() {
-		let one = CheckoutWebView.for(checkout: checkoutURL)
-		let two = CheckoutWebView.for(checkout: checkoutURL)
-		XCTAssertEqual(one, two)
-
-		let presentationController = UIViewController().presentationController!
-		viewController.presentationControllerDidDismiss(presentationController)
-
-		let three = CheckoutWebView.for(checkout: checkoutURL)
-		XCTAssertNotEqual(two, three)
-	}
-
 	func testCheckoutViewDidClickLinkDoesNotInvalidateViewCache() {
 		let one = CheckoutWebView.for(checkout: checkoutURL)
 		let two = CheckoutWebView.for(checkout: checkoutURL)


### PR DESCRIPTION
…ve preload config

### What are you trying to accomplish?

Note: This requires a major release as it's a breaking change to the API (removing preloading config)

prior to change, developers needed to enable preloading flag and then call preload.
```swift
ShopifyCheckout.configuration.preloading.enabled = false
ShopifyCheckout.preload() // does nothing

ShopifyCheckout.configuration.preloading.enabled = true
ShopifyCheckout.preload() // preloads
```

After this change, developers need only call preload
```swift
ShopifyCheckout.preload() // preloads and caches checkout view. If it's not called, checkout view is never cached
```

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](https://github.com/shopify/mobile-checkout-sdk-ios) (if applicable).
