### PR TITLE
Fix memory leak in sample app

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "e6e85dcf8f9eb95baaa8336ad3d7967ea8c36ade",
         "version" : "11.1.0"
       }
+    },
+    {
+      "identity" : "swiftlintplugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
+      "state" : {
+        "revision" : "b1090ecd269dddd96bda0df24ca3f1aa78f33578",
+        "version" : "0.52.4"
+      }
     }
   ],
   "version" : 2

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
@@ -40,7 +40,7 @@ class SettingsViewController: UITableViewController {
 		}
 	}
 
-	private var logs: [String?]? = []
+	private var logs: [String?] = []
 
 	private lazy var preloadingSwitch: UISwitch = {
 		let view = UISwitch()
@@ -77,10 +77,10 @@ class SettingsViewController: UITableViewController {
 		tableView.register(Cell.self, forCellReuseIdentifier: "cell")
 	}
 
-	override func viewDidAppear(_ animated: Bool) {
-		super.viewDidAppear(animated)
+	override func viewWillAppear(_ animated: Bool) {
+		super.viewWillAppear(animated)
 
-		logs = LogReader.shared.readLogs()
+		logs = LogReader.shared.readLogs() ?? []
 
 		DispatchQueue.main.async {
 			self.tableView.reloadSections(IndexSet(integer: Section.logs.rawValue), with: .automatic)
@@ -124,8 +124,7 @@ class SettingsViewController: UITableViewController {
 		case Section.version:
 			return 1
 		case Section.logs:
-			let logsCount = logs?.count ?? 0
-			return logsCount > 10 ? 10 : logsCount
+			return logs.count > 10 ? 10 : logs.count
 		default:
 			return 0
 		}
@@ -153,7 +152,7 @@ class SettingsViewController: UITableViewController {
 			content.secondaryText = currentVersion()
 		case Section.logs:
 			content = UIListContentConfiguration.valueCell()
-			if let logs = logs, indexPath.row < logs.count {
+			if indexPath.row < logs.count {
 				content.text = logs[indexPath.row]
 			} else {
 				content.text = "No log available"

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
@@ -40,6 +40,8 @@ class SettingsViewController: UITableViewController {
 		}
 	}
 
+	private var logs: [String?]? = []
+
 	private lazy var preloadingSwitch: UISwitch = {
 		let view = UISwitch()
 		view.isOn = ShopifyCheckoutKit.configuration.preloading.enabled
@@ -69,17 +71,20 @@ class SettingsViewController: UITableViewController {
 	}
 
 	// MARK: UIViewController
-
-	override func viewWillAppear(_ animated: Bool) {
-		super.viewWillAppear(animated)
-
-		tableView.reloadData()
-	}
-
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
 		tableView.register(Cell.self, forCellReuseIdentifier: "cell")
+	}
+
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+
+		logs = LogReader.shared.readLogs()
+
+		DispatchQueue.main.async {
+			self.tableView.reloadSections(IndexSet(integer: Section.logs.rawValue), with: .automatic)
+		}
 	}
 
 	// MARK: UITableViewDataSource
@@ -119,7 +124,7 @@ class SettingsViewController: UITableViewController {
 		case Section.version:
 			return 1
 		case Section.logs:
-			let logsCount = LogReader.shared.readLogs()?.count ?? 0
+			let logsCount = logs?.count ?? 0
 			return logsCount > 10 ? 10 : logsCount
 		default:
 			return 0
@@ -148,7 +153,7 @@ class SettingsViewController: UITableViewController {
 			content.secondaryText = currentVersion()
 		case Section.logs:
 			content = UIListContentConfiguration.valueCell()
-			if let logs = LogReader.shared.readLogs(), indexPath.row < logs.count {
+			if let logs = logs, indexPath.row < logs.count {
 				content.text = logs[indexPath.row]
 			} else {
 				content.text = "No log available"
@@ -229,6 +234,12 @@ private class Cell: UITableViewCell {
 
 	required init?(coder: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
+	}
+
+	override func prepareForReuse() {
+		super.prepareForReuse()
+
+		accessoryView = nil
 	}
 }
 


### PR DESCRIPTION
Fix memory leak by reloading the logs on the main thread each time the settings view renders

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/shopify/mobile-checkout-sdk-ios) (if applicable).
