### PR TITLE
send presented event to checkout when sheet presented

### DIFF
--- a/Sources/ShopifyCheckoutKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutBridge.swift
@@ -32,7 +32,7 @@ enum CheckoutBridge {
 	static let schemaVersion = "7.0"
 	static let messageHandler = "mobileCheckoutSdk"
 	static var hasInitialized = false
-	static var messageBuffer = Array<() -> Void>()
+	static var messageBuffer = [() -> Void]()
 
 	static var applicationName: String {
 		let theme = ShopifyCheckoutKit.configuration.colorScheme.rawValue
@@ -49,7 +49,7 @@ enum CheckoutBridge {
 
 	static func sendMessage(_ webView: WKWebView, message: String) {
 		let script = "window.MobileCheckoutSdk.dispatchMessage('\(message)');"
-		if (hasInitialized) {
+		if hasInitialized {
 			webView.evaluateJavaScript(script)
 		} else {
 			messageBuffer.append {

--- a/Sources/ShopifyCheckoutKit/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutViewController.swift
@@ -29,6 +29,7 @@ public class CheckoutViewController: UINavigationController {
 		let rootViewController = CheckoutWebViewController(
 			checkoutURL: url, delegate: delegate
 		)
+		rootViewController.notifyPresented()
 		super.init(rootViewController: rootViewController)
 		presentationController?.delegate = rootViewController
 	}

--- a/Sources/ShopifyCheckoutKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutWebViewController.swift
@@ -97,6 +97,10 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
 		loadCheckout()
 	}
 
+	func notifyPresented() {
+		CheckoutBridge.sendMessage(checkoutView, message: "presented")
+	}
+
 	private func loadCheckout() {
 		if checkoutView.url == nil {
 			checkoutView.alpha = 0
@@ -117,6 +121,7 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
 	}
 
 	private func didCancel() {
+		CheckoutBridge.reset()
 		CheckoutWebView.invalidate()
 		delegate?.checkoutDidCancel()
 	}

--- a/Tests/ShopifyCheckoutKitTests/Mocks/MockWebView.swift
+++ b/Tests/ShopifyCheckoutKitTests/Mocks/MockWebView.swift
@@ -1,3 +1,26 @@
+/*
+MIT License
+
+Copyright 2023 - Present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 import WebKit
 import XCTest
 @testable import ShopifyCheckoutKit

--- a/Tests/ShopifyCheckoutKitTests/Mocks/MockWebView.swift
+++ b/Tests/ShopifyCheckoutKitTests/Mocks/MockWebView.swift
@@ -1,0 +1,18 @@
+import WebKit
+import XCTest
+@testable import ShopifyCheckoutKit
+
+class MockWebView: WKWebView {
+
+	var expectedScript = ""
+
+	var evaluateJavaScriptExpectation: XCTestExpectation?
+
+	override func evaluateJavaScript(_ javaScriptString: String) async throws -> Any {
+		if javaScriptString == expectedScript {
+			evaluateJavaScriptExpectation?.fulfill()
+		}
+		return true
+	}
+
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Update to bridge schema v7.0 and send a presented event to checkout when the sheet is presented.

This will help us distinguish between background preloads and presented checkouts, which will be useful for upcoming analytics work.

We'll buffer messages until we've received an init event from checkout, to ensure the event listeners have been attached and the `presented` message will be received.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/shopify/mobile-checkout-sdk-ios) (if applicable).
