### PR TITLE
emit presented event to distinguish between preloads and presented checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1 - December 20, 2023
+
+Emit a presented message to checkout when the checkout sheet is raised as groundwork for supporting analytics / pixel events.
+
 ## 0.8.0 - December 18, 2023
 
 - Adds support for SwiftUI

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The SDK is an open-source [Swift Package library](https://www.swift.org/package-
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/Shopify/checkout-kit-swift", from: "0.8.0")
+  .package(url: "https://github.com/Shopify/checkout-kit-swift", from: "0.8.1")
 ]
 ```
 

--- a/ShopifyCheckoutKit.podspec
+++ b/ShopifyCheckoutKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "0.8.0"
+  s.version = "0.8.1"
 
   s.name    = "ShopifyCheckoutKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutBridge.swift
@@ -44,7 +44,7 @@ enum CheckoutBridge {
 	}
 
 	static func sendMessage(_ webView: WKWebView, messageName: String, messageBody: String?) {
-		var dispatchMessageBody: String
+		let dispatchMessageBody: String
 		if let body = messageBody {
 			dispatchMessageBody = "'\(messageName)', \(body)"
 		} else {

--- a/Sources/ShopifyCheckoutKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutBridge.swift
@@ -44,7 +44,12 @@ enum CheckoutBridge {
 	}
 
 	static func sendMessage(_ webView: WKWebView, messageName: String, messageBody: String?) {
-		let dispatchMessageBody = messageBody != nil ? "'\(messageName)', \(messageBody!)" : "'\(messageName)'"
+		var dispatchMessageBody: String
+		if let body = messageBody {
+			dispatchMessageBody = "'\(messageName)', \(body)"
+		} else {
+			dispatchMessageBody = "'\(messageName)'"
+		}
 		let script = dispatchMessageTemplate(body: dispatchMessageBody)
 		webView.evaluateJavaScript(script)
 	}

--- a/Sources/ShopifyCheckoutKit/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutViewController.swift
@@ -29,6 +29,7 @@ public class CheckoutViewController: UINavigationController {
 		let rootViewController = CheckoutWebViewController(
 			checkoutURL: url, delegate: delegate
 		)
+		rootViewController.notifyPresented()
 		super.init(rootViewController: rootViewController)
 		presentationController?.delegate = rootViewController
 	}

--- a/Sources/ShopifyCheckoutKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutWebView.swift
@@ -112,9 +112,9 @@ class CheckoutWebView: WKWebView {
 	}
 
 	private func dispatchPresentedMessage(_ checkoutDidLoad: Bool, _ checkoutDidPresent: Bool) {
-		if !presentedEventDidDispatch && (checkoutDidLoad && checkoutDidPresent) {
-			presentedEventDidDispatch = true
+		if (checkoutDidLoad && checkoutDidPresent) && !presentedEventDidDispatch {
 			CheckoutBridge.sendMessage(self, messageName: "presented", messageBody: nil)
+			presentedEventDidDispatch = true
 		}
 	}
 }

--- a/Sources/ShopifyCheckoutKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutWebView.swift
@@ -61,6 +61,17 @@ class CheckoutWebView: WKWebView {
 	// MARK: Properties
 
 	weak var viewDelegate: CheckoutWebViewDelegate?
+	var presentedEventDidDispatch = false
+	var checkoutDidPresent: Bool = false {
+		didSet {
+			dispatchPresentedMessage(checkoutDidLoad, checkoutDidPresent)
+		}
+	}
+	var checkoutDidLoad: Bool = false {
+		didSet {
+			dispatchPresentedMessage(checkoutDidLoad, checkoutDidPresent)
+		}
+	}
 
 	// MARK: Initializers
 
@@ -98,6 +109,13 @@ class CheckoutWebView: WKWebView {
 
 	func load(checkout url: URL) {
 		load(URLRequest(url: url))
+	}
+
+	private func dispatchPresentedMessage(_ checkoutDidLoad: Bool, _ checkoutDidPresent: Bool) {
+		if !presentedEventDidDispatch && (checkoutDidLoad && checkoutDidPresent) {
+			presentedEventDidDispatch = true
+			CheckoutBridge.sendMessage(self, messageName: "presented", messageBody: nil)
+		}
 	}
 }
 
@@ -189,7 +207,7 @@ extension CheckoutWebView: WKNavigationDelegate {
 			ShopifyCheckoutKit.configuration.logger.log(message)
 			CheckoutBridge.instrument(self, InstrumentationPayload(name: "checkout_finished_loading", value: Int(diff * 1000), type: .histogram, tags: ["preloading": preloading]))
 		}
-
+		checkoutDidLoad = true
 		timer = nil
 	}
 

--- a/Sources/ShopifyCheckoutKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutWebViewController.swift
@@ -97,6 +97,10 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
 		loadCheckout()
 	}
 
+	func notifyPresented() {
+		checkoutView.checkoutDidPresent = true
+	}
+
 	private func loadCheckout() {
 		if checkoutView.url == nil {
 			checkoutView.alpha = 0

--- a/Sources/ShopifyCheckoutKit/ShopifyCheckoutKit.swift
+++ b/Sources/ShopifyCheckoutKit/ShopifyCheckoutKit.swift
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 import UIKit
 
 /// The version of the `ShopifyCheckoutKit` library.
-public let version = "0.8.0"
+public let version = "0.8.1"
 
 /// The configuration options for the `ShopifyCheckoutKit` library.
 public var configuration = Configuration() {

--- a/Tests/ShopifyCheckoutKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutKitTests/CheckoutBridgeTests.swift
@@ -141,4 +141,55 @@ class CheckoutBridgeTests: XCTestCase {
 			XCTAssertEqual(decodedEvent?.detail.type, .incrementCounter)
 		}
 	}
+
+	func testSendMessageShouldCallEvaluateJavaScriptPresented() {
+		let webView = MockWebView()
+		webView.expectedScript = expectedPresentedScript()
+		let evaluateJavaScriptExpectation = expectation(
+			description: "evaluateJavaScript was called"
+		)
+		webView.evaluateJavaScriptExpectation = evaluateJavaScriptExpectation
+
+		CheckoutBridge.sendMessage(webView, messageName: "presented", messageBody: nil)
+
+		wait(for: [evaluateJavaScriptExpectation], timeout: 1)
+	}
+
+	func testSendMessageWithPayloadEvaulatesJavaScript() {
+		let webView = MockWebView()
+		webView.expectedScript = expectedPayloadScript()
+		let evaluateJavaScriptExpectation = expectation(
+			description: "evaluateJavaScript was called"
+		)
+		webView.evaluateJavaScriptExpectation = evaluateJavaScriptExpectation
+		let payload = InstrumentationPayload(name: "test", value: 1, type: .incrementCounter)
+
+		CheckoutBridge.sendMessage(webView, messageName: "payload", messageBody: "{\"one\": true}")
+
+		wait(for: [evaluateJavaScriptExpectation], timeout: 1)
+	}
+
+	private func expectedPresentedScript() -> String {
+		return """
+		if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
+			window.MobileCheckoutSdk.dispatchMessage('presented');
+		} else {
+			window.addEventListener('mobileCheckoutBridgeReady', function () {
+				window.MobileCheckoutSdk.dispatchMessage('presented');
+			}, {passive: true, once: true});
+		}
+		"""
+	}
+
+	private func expectedPayloadScript() -> String {
+		return """
+		if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
+			window.MobileCheckoutSdk.dispatchMessage('payload', {"one": true});
+		} else {
+			window.addEventListener('mobileCheckoutBridgeReady', function () {
+				window.MobileCheckoutSdk.dispatchMessage('payload', {"one": true});
+			}, {passive: true, once: true});
+		}
+		"""
+	}
 }

--- a/Tests/ShopifyCheckoutKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutKitTests/CheckoutBridgeTests.swift
@@ -162,7 +162,6 @@ class CheckoutBridgeTests: XCTestCase {
 			description: "evaluateJavaScript was called"
 		)
 		webView.evaluateJavaScriptExpectation = evaluateJavaScriptExpectation
-		let payload = InstrumentationPayload(name: "test", value: 1, type: .incrementCounter)
 
 		CheckoutBridge.sendMessage(webView, messageName: "payload", messageBody: "{\"one\": true}")
 

--- a/Tests/ShopifyCheckoutKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutKitTests/CheckoutWebViewTests.swift
@@ -134,39 +134,4 @@ class CheckoutWebViewTests: XCTestCase {
 
 		waitForExpectations(timeout: 0.5, handler: nil)
     }
-
-	func testEmitsPresentedMessageWhenPresentedAndFinishedLoading() {
-		let testCheckoutView = TestCheckoutWebView()
-		testCheckoutView.expectedScript = """
-		if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
-			window.MobileCheckoutSdk.dispatchMessage('presented');
-		} else {
-			window.addEventListener('mobileCheckoutBridgeReady', function () {
-				window.MobileCheckoutSdk.dispatchMessage('presented');
-			}, {passive: true, once: true});
-		}
-		"""
-		let evaluateJavaScriptExpectation = expectation(
-			description: "evaluateJavaScript was called"
-		)
-		testCheckoutView.evaluateJavaScriptExpectation = evaluateJavaScriptExpectation
-
-		testCheckoutView.checkoutDidPresent = true
-		testCheckoutView.checkoutDidLoad = true
-
-		wait(for: [evaluateJavaScriptExpectation], timeout: 1)
-	}
-}
-
-class TestCheckoutWebView: CheckoutWebView {
-	var expectedScript = ""
-
-	var evaluateJavaScriptExpectation: XCTestExpectation?
-
-	override func evaluateJavaScript(_ javaScriptString: String) async throws -> Any {
-		if javaScriptString == expectedScript {
-			evaluateJavaScriptExpectation?.fulfill()
-		}
-		return true
-	}
 }

--- a/Tests/ShopifyCheckoutKitTests/Mocks/MockWebView.swift
+++ b/Tests/ShopifyCheckoutKitTests/Mocks/MockWebView.swift
@@ -1,0 +1,43 @@
+/*
+MIT License
+
+Copyright 2023 - Present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import WebKit
+import XCTest
+@testable import ShopifyCheckoutKit
+
+class MockWebView: WKWebView {
+
+	var expectedScript = ""
+
+	var evaluateJavaScriptExpectation: XCTestExpectation?
+
+	override func evaluateJavaScript(_ javaScriptString: String) async throws -> Any {
+		if javaScriptString == expectedScript {
+			evaluateJavaScriptExpectation?.fulfill()
+		} else {
+			print("Script did not match. Actual: \(javaScriptString), expected: \(expectedScript)")
+		}
+		return true
+	}
+
+}

--- a/Tests/ShopifyCheckoutKitTests/Mocks/MockWebView.swift
+++ b/Tests/ShopifyCheckoutKitTests/Mocks/MockWebView.swift
@@ -34,8 +34,6 @@ class MockWebView: WKWebView {
 	override func evaluateJavaScript(_ javaScriptString: String) async throws -> Any {
 		if javaScriptString == expectedScript {
 			evaluateJavaScriptExpectation?.fulfill()
-		} else {
-			print("Script did not match. Actual: \(javaScriptString), expected: \(expectedScript)")
 		}
 		return true
 	}


### PR DESCRIPTION
### What are you trying to accomplish?

Emit a presented event from the SDK to checkout when the sheet is raised.  This will help with analytics.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](https://github.com/shopify/mobile-checkout-sdk-ios) (if applicable).
