### PR TITLE
Add bridge on init, remove on invalidate/deinit

### DIFF
--- a/Sources/ShopifyCheckoutKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutWebView.swift
@@ -55,6 +55,8 @@ class CheckoutWebView: WKWebView {
 	}
 
 	static func invalidate() {
+		cache?.view.configuration.userContentController
+			.removeScriptMessageHandler(forName: CheckoutBridge.messageHandler)
 		cache = nil
 	}
 
@@ -64,12 +66,16 @@ class CheckoutWebView: WKWebView {
 	var presentedEventDidDispatch = false
 	var checkoutDidPresent: Bool = false {
 		didSet {
-			dispatchPresentedMessage(checkoutDidLoad, checkoutDidPresent)
+			if checkoutDidPresent {
+				dispatchPresentedMessage(checkoutDidLoad, checkoutDidPresent)
+			}
 		}
 	}
 	var checkoutDidLoad: Bool = false {
 		didSet {
-			dispatchPresentedMessage(checkoutDidLoad, checkoutDidPresent)
+			if checkoutDidLoad {
+				dispatchPresentedMessage(checkoutDidLoad, checkoutDidPresent)
+			}
 		}
 	}
 
@@ -87,6 +93,14 @@ class CheckoutWebView: WKWebView {
 		#endif
 
 		navigationDelegate = self
+
+		configuration.userContentController
+			.add(self, name: CheckoutBridge.messageHandler)
+	}
+
+	deinit {
+		configuration.userContentController
+			.removeScriptMessageHandler(forName: CheckoutBridge.messageHandler)
 	}
 
 	required init?(coder: NSCoder) {
@@ -94,18 +108,6 @@ class CheckoutWebView: WKWebView {
 	}
 
 	// MARK: -
-
-	override func didMoveToSuperview() {
-		super.didMoveToSuperview()
-
-		configuration.userContentController
-			.removeScriptMessageHandler(forName: CheckoutBridge.messageHandler)
-
-		if superview != nil {
-			configuration.userContentController
-				.add(self, name: CheckoutBridge.messageHandler)
-		}
-	}
 
 	func load(checkout url: URL) {
 		load(URLRequest(url: url))


### PR DESCRIPTION
### What are you trying to accomplish?

Add bridge on init, remove on invalidate/deinit

This allows us to continue to receive events via the bridge when the view is in the background (preload).

---

### Before you merge

#### Testing

- [ ] I've added tests to support my implementation

#### Contribution guidelines

- [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CONTRIBUTING.md).
- [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CODE_OF_CONDUCT.md).

#### Documentation

- [ ] I've updated any documentation related to these changes.
- [ ] I've updated the [README](https://github.com/shopify/mobile-checkout-sdk-ios).

#### Versioning

- [ ] I have bumped the version number in the [`.podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.

### After merging

If your changes required a version bump, please add an entry under the [Releases](https://github.com/Shopify/checkout-kit-swift/releases) page - doing so will trigger a CI workflow to publish the latest Cocoapod.
